### PR TITLE
Added ability to load default config in configus

### DIFF
--- a/lib/configus.rb
+++ b/lib/configus.rb
@@ -6,8 +6,8 @@ module Configus
   autoload :Proxy, 'configus/proxy'
   autoload :Config, 'configus/config'
 
-  def self.build(env, &block)
-    @config = Builder.build(env, &block)
+  def self.build(env, yaml_configs = [], &block)
+    @config = Builder.build(env, yaml_configs, &block)
   end
 
   def self.config

--- a/lib/configus/builder.rb
+++ b/lib/configus/builder.rb
@@ -2,16 +2,16 @@ module Configus
   class Builder
 
     class << self
-      def build(current_env, &block)
+      def build(current_env, default_configs = [], &block)
         b = new(current_env, block)
-        Config.new(b.result)
+        Config.new(b.result, default_configs)
       end
     end
 
     def initialize(current_env, block)
       @current_env = current_env.to_sym
       @envs = {}
-      instance_eval &block
+      instance_eval(&block)
     end
 
     def result(env = nil)

--- a/spec/configus/builder_spec.rb
+++ b/spec/configus/builder_spec.rb
@@ -22,6 +22,7 @@ describe Configus::Builder do
         end
       end
     end
+
     builder = Configus::Builder.new(:development, p)
     @options = builder.result
   end

--- a/spec/configus/config_spec.rb
+++ b/spec/configus/config_spec.rb
@@ -96,3 +96,29 @@ describe "Hardcore" do
   end
 end
 
+describe "Config with default config" do
+  before do
+    @options = {
+      :foo => 'bar',
+      :sections => {
+        :first => 'first_value',
+        :second => 'second_value',
+        :another_key => {
+          :key => :value
+        }
+      },
+      :pairs => { :pkay => "vkay" }
+    }
+
+    configs = %w(test.yml).map {|f| File.join(fixtures_path, f)}
+    @config = Configus::Config.new(@options, configs)
+  end
+
+  it 'options from file should be defined in configus' do
+    @config.another_option.some_thing == "value"
+  end
+
+  it 'option from config file should be overwritten by configus dsl' do
+    @config.foo == 'bar'
+  end
+end

--- a/spec/fixtures/test.yml
+++ b/spec/fixtures/test.yml
@@ -1,0 +1,4 @@
+---
+foo: key
+another_option:
+  some_thing: value

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,7 @@ if ENV["TRAVIS"]
   require 'coveralls'
   Coveralls.wear!
 end
+
+def fixtures_path
+  @path ||= File.expand_path(File.join(__FILE__, "../fixtures"))
+end


### PR DESCRIPTION
### Problem

Do you have some configuration values ​​that are not worth keeping in the repository, but for you it is important to keep correct the structure of the configuration. Usually in this case used YAML files that are simply copied (for example `my_great_config.yml.example`).
Such a situation is common in opensource projects: provided example configuration file that you copy and modify to suit your needs. Everything works well while the example file is not updated, and you do not miss this update.
### Solution

This PR allows you to specify the `configus` default configs (one, or many) that it will load and fill the default values. After this - you only need to overwrite specific keys values via `configus` DSL.

For example:

``` ruby
configs = ["secret_keys.sample.yml", "mail_sandbox.sample.yml", "another_config.sample.yml"].map do |c|
  File.join(Rails.root, 'config', c)
end

Configus.build Rails.env, configs do
  env :production do
    # ... overwrite some keys
  end
end
```
