### PR TITLE
Travis: Modern CI matrix, now green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
-rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1  
-  - jruby-9.1.10.0
+matrix:
+  include:
+    - rvm: 2.2.7
+    - rvm: 2.3.4
+    - rvm: 2.4.1  
+    - rvm: jruby-9.1.10.0
+      jdk: oraclejdk8
+      env:
+        - JRUBY_OPTS=--debug
 before_install:
   - gem install bundler
+cache:
+  - bundler  
 dist: trusty
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - rbx
-  - jruby
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1  
+  - jruby-9.1.10.0
+before_install:
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ rvm:
   - jruby-9.1.10.0
 before_install:
   - gem install bundler
+dist: trusty
+sudo: false


### PR DESCRIPTION
This PR updates the CI matrix to the latest generally available Ruby versions.

- drop rbx (uninstallable)
- specify exact JRuby version (and use `JRUBY_OPTS=--debug` to get code coverage numbers)
- use current Ruby versions
- configured Travis to use `dist: trusty` (instead of the default Precise)

---

Issues encountered: 

- too-long install time for Travis (was Precise missing the `haveged` apt package?) - this was fixed by switching to `dist: trusty` on Travis