### PR TITLE
Travis: jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
     - rvm: 2.2.7
     - rvm: 2.3.4
     - rvm: 2.4.1  
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.13.0
       jdk: oraclejdk8
       env:
         - JRUBY_OPTS=--debug


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html